### PR TITLE
New version of aws-sdk has a validation for Number, doesn't accept String anymore

### DIFF
--- a/lib/s3-upload-stream.js
+++ b/lib/s3-upload-stream.js
@@ -71,7 +71,7 @@ module.exports = {
 					Bucket: destinationDetails.Bucket,
 					Key: destinationDetails.Key,
 					UploadId: self.multipartUploadID,
-					PartNumber: localChunkNumber.toString()
+					PartNumber: localChunkNumber
 				},
 				function (err, result)
 				{


### PR DESCRIPTION
This was an error I was getting:

```
Error: Expected params.PartNumber to be a number
at fail (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/param_validator.js:125:26)
at validateType (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/param_validator.js:152:10)
at validateScalar (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/param_validator.js:111:21)
at validateMember (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/param_validator.js:75:21)
at validateStructure (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/param_validator.js:55:14)
at validate (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/param_validator.js:30:17)
at Request.VALIDATE_PARAMETERS (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/event_listeners.js:111:32)
at Request.callListeners (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/sequential_executor.js:132:20)
at Request.<anonymous> (/Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/sequential_executor.js:123:18)
at /Users/marekhrabe/dev/generator/plugins/piffle-exporter/node_modules/aws-sdk/lib/event_listeners.js:98:9
```
