### PR TITLE
Updating to require node 0.10.x or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "readmeFilename": "README.md",
   "main": "./lib/s3-upload-stream.js",
   "engines": {
-    "node": "*"
+	  "node": ">=0.10.x"
   },
   "scripts": {
     "test": "mocha -R spec -s 100 ./tests/test.js"


### PR DESCRIPTION
Now that https://github.com/nathanpeck/s3-upload-stream/blob/master/lib/s3-upload-stream.js#L18-18 uses `WritableStream` we can't allow versions below `0.10`.
