### PR TITLE
Use setImmediate polyfill for browsers

### DIFF
--- a/lib/s3-upload-stream.js
+++ b/lib/s3-upload-stream.js
@@ -1,8 +1,7 @@
 var Writable = require('stream').Writable,
     events = require("events");
 
-// fall back to setTimeout when setImmediate is not available
-((typeof setImmediate)[0] == 'f') || (setImmediate = setTimeout);
+require("setimmediate");
 
 var cachedClient;
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "aws-sdk":    "2.0.17",
     "chai":       "1.8.1"
   },
+  "dependencies": {
+    "setimmediate": "1.0.2"
+  },
   "keywords": [
     "aws",
     "s3",


### PR DESCRIPTION
`setImmediate` is not available in some browser environments, like Firefox and Chrome, so this brings in the [setImmediate polyfill](https://github.com/YuzuJS/setImmediate) through npm. It should [short-circuit and do nothing](https://github.com/YuzuJS/setImmediate/blob/master/setImmediate.js#L4-L6) when it's not needed, so there should be no downside to including it here, besides the addition of an npm dependency.

If the npm dependency is not desired, I also tested out an alternate approach in https://github.com/konklone/s3-upload-stream/commit/a3e120ce706f062a0badd51fd543be4bb497183b which simply falls back `setImmediate` to `setTimeout`. My understanding is that that works too, but is less efficient. Then again, [setImmediate.js](https://github.com/YuzuJS/setImmediate/blob/master/setImmediate.js) is doing a lot. The choice is yours -- what's submitted here is the polyfill.
