### PR TITLE
Make variable names consistent in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ var AWS      = require('aws-sdk'),
     s3Stream = require('../lib/s3-upload-stream.js')(new AWS.S3());
 
 var read = fs.createReadStream('/path/to/a/file');
-var upload = s3Client.upload({
+var upload = s3Stream.upload({
   Bucket: "bucket-name",
   Key: "key-name",
   ACL: "public-read",
@@ -143,7 +143,7 @@ var AWS      = require('aws-sdk'),
     s3Stream = require('../lib/s3-upload-stream.js')(new AWS.S3());
 
 var read = fs.createReadStream('/path/to/a/file');
-var upload = s3Client.upload(
+var upload = s3Stream.upload(
   {
     Bucket: "bucket-name",
     Key: "key-name",
@@ -208,7 +208,7 @@ var AWS      = require('aws-sdk'),
     s3Stream = require('../lib/s3-upload-stream.js')(new AWS.S3());
 
 var read = fs.createReadStream('/path/to/a/file');
-var upload = new s3Client.upload({
+var upload = new s3Stream.upload({
   "Bucket": "bucket-name",
   "Key": "key-name"
 });
@@ -229,7 +229,7 @@ var AWS      = require('aws-sdk'),
     s3Stream = require('../lib/s3-upload-stream.js')(new AWS.S3());
 
 var read = fs.createReadStream('/path/to/a/file');
-var upload = new s3Client.upload({
+var upload = new s3Stream.upload({
   "Bucket": "bucket-name",
   "Key": "key-name"
 });


### PR DESCRIPTION
In the last README update, the variable names of the client instance got out of sync.
