### PR TITLE
Change handling of end override so finish gets called at a more appropriate time

### DIFF
--- a/lib/s3-upload-stream.js
+++ b/lib/s3-upload-stream.js
@@ -314,7 +314,6 @@ Client.prototype.upload = function (destinationDetails, sessionDetails) {
             // Emit both events for backwards compatibility, and to follow the spec.
             if(cb) cb(err, result);
             ws.emit('uploaded', result);
-            ws.emit('finish', result);
             started = false;
           }
         }

--- a/lib/s3-upload-stream.js
+++ b/lib/s3-upload-stream.js
@@ -265,35 +265,36 @@ Client.prototype.upload = function (destinationDetails, sessionDetails) {
   // Overwrite the end method so that we can hijack it to flush the last part and then complete
   // the multipart upload
   ws.originalEnd = ws.end;
-  ws.end = function (Part, encoding, callback) {
-    ws.originalEnd(Part, encoding, function afterDoneWithOriginalEnd() {
-      if (Part)
-        absorbBuffer(Part);
+    ws.end = function (Part, encoding, callback) {
+    if (Part)
+      absorbBuffer(Part);
 
-      // Upload any remaining data
-      var uploadRemainingData = function () {
-        if (receivedBuffersLength > 0) {
-          uploadHandler(uploadRemainingData);
-          return;
-        }
+    // Upload any remaining data
+    var uploadRemainingData = function (cb) {
+      if (receivedBuffersLength > 0) {
+        uploadHandler(uploadThenCall);
+        return;
+      }
 
-        if (pendingParts > 0) {
-          setTimeout(uploadRemainingData, 50); // Wait 50 ms for the pending uploads to finish before trying again.
-          return;
-        }
+      if (pendingParts > 0) {
+        setTimeout(uploadThenCall, 50); // Wait 50 ms for the pending uploads to finish before trying again.
+        return;
+      }
 
-        completeUpload();
-      };
+      return completeUpload(cb);
+    };
 
-      uploadRemainingData();
+    var callOriginal = function () {
+      return ws.originalEnd(Part, encoding, callback);
+    };
 
-      if (typeof callback == 'function')
-        callback();
-    });
+    var uploadThenCall = uploadRemainingData.bind(null, callOriginal);
+
+    uploadThenCall();
   };
 
   // Turn all the individual parts we uploaded to S3 into a finalized upload.
-  var completeUpload = function () {
+  var completeUpload = function (cb) {
     // There is a possibility that the incoming stream was empty, therefore the MPU never started
     // and cannot be finalized.
     if (multipartUploadID) {
@@ -311,6 +312,7 @@ Client.prototype.upload = function (destinationDetails, sessionDetails) {
             abortUpload('Failed to complete the multipart upload on S3: ' + JSON.stringify(err));
           else {
             // Emit both events for backwards compatibility, and to follow the spec.
+            if(cb) cb(err, result);
             ws.emit('uploaded', result);
             ws.emit('finish', result);
             started = false;


### PR DESCRIPTION
In the current version, by calling `ws.originalEnd` before cleaning up remaining data, a `finish` event is emitted which can cause problems if the user's code assumes `finish` means no more work will be done. I ran into this with [pump](https://github.com/mafintosh/pump), which will destroy a stream as soon as it gets a finish/close/end. Thus, the early `finish` was swallowing errors which would have otherwise been reported. Seems probable that, without this fix, the last flush of data could be accidentally blocked.