### PR TITLE
fix sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ Removing global state, and adding pause and resume functionality.
 var AWS      = require('aws-sdk'),
     zlib     = require('zlib'),
     fs       = require('fs');
-    s3Stream = require('s3-upload-stream')(new AWS.S3()),
 
 // Set the client to be used for the upload.
 AWS.config.loadFromPath('./config.json');
+
+var s3Stream = require('s3-upload-stream')(new AWS.S3());
 
 // Create the streams
 var read = fs.createReadStream('/path/to/a/file');


### PR DESCRIPTION
aws config has to be loaded before creating S3-instance

code was already correct here: https://github.com/nathanpeck/s3-upload-stream/blob/master/examples/upload.js